### PR TITLE
fix: ToFixed fractional part discard problem

### DIFF
--- a/entities/fraction.go
+++ b/entities/fraction.go
@@ -136,7 +136,6 @@ func (f *Fraction) ToFixed(decimalPlaces uint, opt ...number.Option) string {
 	f.opts.Apply(opt...)
 	f.opts.Apply(number.WithDecimalPlaces(decimalPlaces))
 
-	d := decimal.NewFromBigInt(big.NewInt(0).Div(f.Numerator, f.Denominator), 0)
-
+	d := decimal.NewFromBigInt(f.Numerator, 0).Div(decimal.NewFromBigInt(f.Denominator, 0))
 	return number.DecimalFormat(d, f.opts)
 }

--- a/entities/percent_test.go
+++ b/entities/percent_test.go
@@ -1,0 +1,74 @@
+package entities
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/miraclesu/uniswap-sdk-go/number"
+)
+
+// nolint:dupl
+func TestPercent_ToSignificant(t *testing.T) {
+	type fields struct {
+		num, deno *big.Int
+	}
+	type args struct {
+		significantDigits uint
+		opt               []number.Option
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			"returns the value scaled by 100",
+			fields{big.NewInt(154), big.NewInt(10000)},
+			args{significantDigits: 3},
+			"1.54",
+		},
+	}
+	for _, tt := range tests {
+		got := NewPercent(tt.fields.num, tt.fields.deno).ToSignificant(tt.args.significantDigits, tt.args.opt...)
+		want := tt.want
+		t.Run(tt.name, func(t *testing.T) {
+			if got != want {
+				t.Errorf("ToSignificant() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// nolint: dupl
+func TestPercent_ToFixed(t *testing.T) {
+	type fields struct {
+		num, deno *big.Int
+	}
+	type args struct {
+		decimalPlaces uint
+		opt           []number.Option
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			"returns the value scaled by 100",
+			fields{big.NewInt(154), big.NewInt(10000)},
+			args{decimalPlaces: 2},
+			"1.54",
+		},
+	}
+	for _, tt := range tests {
+		got := NewPercent(tt.fields.num, tt.fields.deno).ToFixed(tt.args.decimalPlaces, tt.args.opt...)
+		want := tt.want
+		t.Run(tt.name, func(t *testing.T) {
+			if got != want {
+				t.Errorf("ToFixed() = %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
test case ref: https://github.com/Uniswap/uniswap-sdk-core/blob/main/src/entities/fractions/percent.test.ts#L47

issue: big int div gilt nicht für dezimale Berechnungen
```go
// d = 1
d := decimal.NewFromBigInt(f.Numerator, 0).Div(decimal.NewFromBigInt(f.Denominator, 0))
```

fixed: use decimal div
```go
// d = 1.54
d := decimal.NewFromBigInt(f.Numerator, 0).Div(decimal.NewFromBigInt(f.Denominator, 0))
```